### PR TITLE
Add build rules for api protos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ google/internal
 google/protobuf
 .project
 artman-genfiles/
+bazel-api-common-protos
+bazel-bin
+bazel-genfiles
+bazel-out
+bazel-testlogs

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc.
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,248 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = [
+    "//visibility:private",
+])
+
+proto_library(
+    name = "google_api_annotations_proto",
+    srcs = ["google/api/annotations.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":google_api_http_proto",
+        "@com_google_protobuf//:descriptor_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_auth_proto",
+    srcs = ["google/api/auth.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":google_api_annotations_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_billing_proto",
+    srcs = ["google/api/billing.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":google_api_annotations_proto",
+        ":google_api_metric_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_backend_proto",
+    srcs = ["google/api/backend.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "google_api_config_change_proto",
+    srcs = ["google/api/config_change.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "google_api_consumer_proto",
+    srcs = ["google/api/consumer.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "google_api_context_proto",
+    srcs = ["google/api/context.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "google_api_control_proto",
+    srcs = ["google/api/control.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "google_api_distribution_proto",
+    srcs = ["google/api/distribution.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":google_api_annotations_proto",
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_documentation_proto",
+    srcs = ["google/api/documentation.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "google_api_endpoint_proto",
+    srcs = ["google/api/endpoint.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":google_api_annotations_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_http_proto",
+    srcs = ["google/api/http.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "google_api_httpbody_proto",
+    srcs = ["google/api/httpbody.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "google_api_label_proto",
+    srcs = ["google/api/label.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "google_api_log_proto",
+    srcs = ["google/api/log.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":google_api_label_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_logging_proto",
+    srcs = ["google/api/logging.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":google_api_annotations_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_metric_proto",
+    srcs = ["google/api/metric.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":google_api_label_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_monitored_resource_proto",
+    srcs = ["google/api/monitored_resource.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":google_api_label_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_monitoring_proto",
+    srcs = ["google/api/monitoring.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":google_api_annotations_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_quota_proto",
+    srcs = ["google/api/quota.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":google_api_annotations_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_service_proto",
+    srcs = ["google/api/service.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+      ":google_api_annotations_proto",
+      ":google_api_auth_proto",
+      ":google_api_backend_proto",
+      ":google_api_billing_proto",
+      ":google_api_context_proto",
+      ":google_api_control_proto",
+      ":google_api_documentation_proto",
+      ":google_api_experimental_experimental_proto",
+      ":google_api_endpoint_proto",
+      ":google_api_http_proto",
+      ":google_api_label_proto",
+      ":google_api_log_proto",
+      ":google_api_logging_proto",
+      ":google_api_metric_proto",
+      ":google_api_monitored_resource_proto",
+       ":google_api_monitoring_proto",
+       ":google_api_quota_proto",
+       ":google_api_source_info_proto",
+       ":google_api_system_parameter_proto",
+       ":google_api_usage_proto",
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:api_proto",
+        "@com_google_protobuf//:type_proto",
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_source_info_proto",
+    srcs = ["google/api/source_info.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_system_parameter_proto",
+    srcs = ["google/api/system_parameter.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "google_api_usage_proto",
+    srcs = ["google/api/usage.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":google_api_annotations_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_experimental_experimental_proto",
+    srcs = ["google/api/experimental/experimental.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":google_api_annotations_proto",
+        ":google_api_experimental_authorization_config_proto",
+    ],
+)
+
+proto_library(
+    name = "google_api_experimental_authorization_config_proto",
+    srcs = ["google/api/experimental/authorization_config.proto"],
+    visibility = ["//visibility:public"],
+)
+
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,23 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# proto_library, cc_proto_library, and java_proto_library rules implicitly
+# depend on @com_google_protobuf for protoc and proto runtimes.
+# This statement defines the @com_google_protobuf repo.
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "1f8b9b202e9a4e467ff0b0f25facb1642727cdf5e69092038f15b37c75b99e45",
+    strip_prefix = "protobuf-3.5.1",
+    urls = ["https://github.com/google/protobuf/archive/v3.5.1.zip"],
+)


### PR DESCRIPTION
Added some basic build rules for google/api protos.  This doesn't include the `servicecontrol` or `servicemanagement` dirs, but it should be pretty easy to add them.

Made the BUILD file a top level and fully qualified the proto names.  This makes it easier to sync IMO, since the directory structure below more closely matches other repos.

Visibility is private by default, with each rule being public to avoid accidental exposure of rules in the future.  

Lastly, I got some warnings about unused protos.  Might be worth cleaning them up:

```
INFO: From Generating Descriptor Set proto_library //:google_api_distribution_proto:
google/api/distribution.proto: warning: Import google/protobuf/any.proto but not used.
google/api/distribution.proto: warning: Import google/protobuf/timestamp.proto but not used.
INFO: From Generating Descriptor Set proto_library //:google_api_billing_proto:
google/api/billing.proto: warning: Import google/api/metric.proto but not used.
INFO: From Generating Descriptor Set proto_library //:google_api_service_proto:
google/api/service.proto: warning: Import google/api/label.proto but not used.
google/api/service.proto: warning: Import google/protobuf/any.proto but not used.
```
