### PR TITLE
move longrunning annotations

### DIFF
--- a/google/api/annotations.proto
+++ b/google/api/annotations.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package google.api;
 
 import "google/api/http.proto";
+import "google/api/longrunning.proto";
 import "google/api/metadata.proto";
 import "google/api/resources.proto";
 import "google/api/retry.proto";
@@ -87,6 +88,13 @@ extend google.protobuf.MethodOptions {
   // The HTTP bindings for this method.
   // See `google/api/http.proto`.
   HttpRule http = 72295728;
+}
+
+extend google.protobuf.MethodOptions {
+  // The types that are returned from long-running operations.
+  // Required for methods that return google.longrunning.Operation; invalid
+  // otherwise.
+  LongrunningOperationTypes longrunning_operation_types = 1049;
 }
 
 // -- These are not annotations, but placing them here solves for a common

--- a/google/api/annotations.proto
+++ b/google/api/annotations.proto
@@ -89,7 +89,6 @@ extend google.protobuf.MethodOptions {
   HttpRule http = 72295728;
 }
 
-
 // -- These are not annotations, but placing them here solves for a common
 // -- potential import issue.
 

--- a/google/api/longrunning.proto
+++ b/google/api/longrunning.proto
@@ -16,8 +16,6 @@ syntax = "proto3";
 
 package google.api;
 
-import "google/protobuf/descriptor.proto";
-
 // A message representing types returned by a longrunning operation.
 message LongrunningOperationTypes {
   // Required. The message name of the primary return type for this
@@ -30,11 +28,4 @@ message LongrunningOperationTypes {
 
   // The metadata message name for this long-running operation.
   string metadata = 2;
-}
-
-extend google.protobuf.MethodOptions {
-  // The types that are returned from long-running operations.
-  // Required for methods that return google.longrunning.Operation; invalid
-  // otherwise.
-  LongrunningOperationTypes longrunning_operation_types = 1049;
 }

--- a/google/api/longrunning.proto
+++ b/google/api/longrunning.proto
@@ -1,0 +1,40 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/protobuf/descriptor.proto";
+
+// A message representing types returned by a longrunning operation.
+message LongrunningOperationTypes {
+  // Required. The message name of the primary return type for this
+  // long-running operation.
+  // This type will be used to deserialize the LRO's response.
+  //
+  // If the response is in a different package from the rpc, a fully-qualified
+  // message name must be used (e.g. "google.protobuf.Empty").
+  string response = 1;
+
+  // The metadata message name for this long-running operation.
+  string metadata = 2;
+}
+
+extend google.protobuf.MethodOptions {
+  // The types that are returned from long-running operations.
+  // Required for methods that return google.longrunning.Operation; invalid
+  // otherwise.
+  LongrunningOperationTypes longrunning_operation_types = 1049;
+}

--- a/google/longrunning/operations.proto
+++ b/google/longrunning/operations.proto
@@ -18,7 +18,6 @@ package google.longrunning;
 
 import "google/api/annotations.proto";
 import "google/protobuf/any.proto";
-import "google/protobuf/descriptor.proto";
 import "google/protobuf/empty.proto";
 import "google/rpc/status.proto";
 
@@ -157,25 +156,4 @@ message CancelOperationRequest {
 message DeleteOperationRequest {
   // The name of the operation resource to be deleted.
   string name = 1;
-}
-
-// The protocol buffer types used to indirectly support this method.
-message OperationTypes {
-  // Required. The message name of the primary return type for this
-  // long-running operation.
-  // This type will be used to deserialize the LRO's response.
-  //
-  // If the response is in a different package from the rpc, a fully-qualified
-  // message name must be used (e.g. "google.protobuf.Empty").
-  string response = 1;
-
-  // The metadata message name for this long-running operation.
-  string metadata = 2;
-}
-
-extend google.protobuf.MethodOptions {
-  // The types that are returned from long-running operations.
-  // Required for methods that return google.longrunning.Operation; invalid
-  // otherwise.
-  OperationTypes operation_types = 1049;
 }


### PR DESCRIPTION
into the google.api package with other annotations.