### PR TITLE
Refactor LRO annotation again.

### DIFF
--- a/google/api/annotations.proto
+++ b/google/api/annotations.proto
@@ -88,9 +88,9 @@ extend google.protobuf.MethodOptions {
   // Additional information regarding long-running operations.
   // In particular, this specifies the types that are returned from
   // long-running operations.
-  // Required for methods that return google.longrunning.Operation; invalid
+  // Required for methods that return `google.longrunning.Operation`; invalid
   // otherwise.
-  LRO lro = 1049;
+  OperationData operation_data = 1049;
 
   // The HTTP bindings for this method.
   // See `google/api/http.proto`.

--- a/google/api/annotations.proto
+++ b/google/api/annotations.proto
@@ -85,16 +85,16 @@ extend google.protobuf.MethodOptions {
   // See `google/api/signature.proto`.
   MethodSignature method_signature = 1051;
 
+  // Additional information regarding long-running operations.
+  // In particular, this specifies the types that are returned from
+  // long-running operations.
+  // Required for methods that return google.longrunning.Operation; invalid
+  // otherwise.
+  LRO lro = 1049;
+
   // The HTTP bindings for this method.
   // See `google/api/http.proto`.
   HttpRule http = 72295728;
-}
-
-extend google.protobuf.MethodOptions {
-  // The types that are returned from long-running operations.
-  // Required for methods that return google.longrunning.Operation; invalid
-  // otherwise.
-  LongrunningOperationTypes longrunning_operation_types = 1049;
 }
 
 // -- These are not annotations, but placing them here solves for a common

--- a/google/api/longrunning.proto
+++ b/google/api/longrunning.proto
@@ -17,7 +17,7 @@ syntax = "proto3";
 package google.api;
 
 // A message representing types returned by a longrunning operation.
-message LRO {
+message OperationData {
   // Required. The message name of the primary return type for this
   // long-running operation.
   // This type will be used to deserialize the LRO's response.

--- a/google/api/longrunning.proto
+++ b/google/api/longrunning.proto
@@ -17,15 +17,15 @@ syntax = "proto3";
 package google.api;
 
 // A message representing types returned by a longrunning operation.
-message LongrunningOperationTypes {
+message LRO {
   // Required. The message name of the primary return type for this
   // long-running operation.
   // This type will be used to deserialize the LRO's response.
   //
   // If the response is in a different package from the rpc, a fully-qualified
   // message name must be used (e.g. "google.protobuf.Empty").
-  string response = 1;
+  string response_type = 1;
 
-  // The metadata message name for this long-running operation.
-  string metadata = 2;
+  // Required. The metadata message name for this long-running operation.
+  string metadata_type = 2;
 }


### PR DESCRIPTION
This makes the naming more generic to allow a future addition of a URI prefix when necessary.

@pongad Feel free to merge if you are happy with it. (Already discussed with @andreamlin in chat.)

/cc @chrisdunelm @alexander-fenster 