### PR TITLE
Support a Docker push.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,56 @@
 version: 2
+workflows:
+  version: 2
+  tests:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - publish_image:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/
 jobs:
   build:
     docker:
-      - image: ubuntu
+      - image: alpine:3.8
     steps:
       - checkout
       - run:
           name: Install protoc.
           command: |
             apt-get update && apt-get install -y curl unzip
-            curl -o ~/protoc3.zip -L https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip
+            curl -o ~/protoc3.zip -L https://github.com/google/protobuf/releases/download/v${PROTO_VERSION}/protoc-${PROTO_VERSION}-linux-x86_64.zip
             unzip ~/protoc3.zip -d ~/protoc3
             mv ~/protoc3/bin/* /usr/local/bin/
             mv ~/protoc3/include/* /usr/local/include/
+          environment:
+            PROTO_VERSION: 3.6.1
       - run:
           name: Verify that the protos compile.
           command: protoc --proto_path=. google/**/*.proto -o /tmp/google.desc
+  publish_image:
+    docker:
+      - image: google/cloud-sdk
+    steps:
+      - checkout
+      - run:
+          name: Build Docker image.
+          command: docker build . \
+            -t gcr.io/gapic-images/api-common-protos:${CIRCLE_TAG} \
+            -t gcr.io/gapic-images/api-common-protos:latest
+      - run:
+          name: Set up authentication to Google Container Registry.
+          command: |
+            echo ${GCLOUD_SERVICE_KEY} > ${GOOGLE_APPLICATION_CREDENTIALS}
+            gcloud auth configure-docker
+      - run:
+          name: Push Docker image to Google Container Registry.
+          command: |
+            docker push gcr.io/gapic-images/api-common-protos:${CIRCLE_TAG}
+            docker push gcr.io/gapic-images/api-common-protos:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: alpine:3.8
+      - image: ubuntu:16.04
     steps:
       - checkout
       - run:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.circleci
+.git
+.gitignore
+
+OWNERS
+README.google
+google/internal
+google/protobuf
+.project
+artman-genfiles/
+bazel-api-common-protos
+bazel-bin
+bazel-genfiles
+bazel-out
+bazel-testlogs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
 FROM alpine:3.8
 
+# Install curl and unzip, which are required to add protoc.
+RUN apk add --no-cache curl unzip
+
+# Add protoc.
+ENV PROTOBUF_VERSION 3.6.1
+RUN mkdir -p /usr/src/protoc/ \
+    && curl --location https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip > /usr/src/protoc/protoc-${PROTOBUF_VERSION}.zip \
+    && cd /usr/src/protoc/ \
+    && unzip protoc-${PROTOBUF_VERSION}.zip \
+    && rm protoc-${PROTOBUF_VERSION}.zip \
+    && ln -s /usr/src/protoc/bin/protoc /usr/local/bin/protoc
+
 # Add the protos to the Docker image.
 ADD ./google /protos/google
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,9 @@ RUN mkdir -p /usr/src/protoc/ \
     && cd /usr/src/protoc/ \
     && unzip protoc-${PROTOBUF_VERSION}.zip \
     && rm protoc-${PROTOBUF_VERSION}.zip \
-    && ln -s /usr/src/protoc/bin/protoc /usr/local/bin/protoc
+    && ln -s /usr/src/protoc/bin/protoc /usr/local/bin/protoc \
+    && mkdir -p /protos/ \
+    && cp -R /usr/src/protoc/include/google/ /protos/google/
 
 # Add the protos to the Docker image.
-ADD ./google /protos/google
-
-# Add Bazel build data to the image.
-ADD ./BUILD.bazel /protos/BUILD.bazel
-ADD ./WORKSPACE /protos/WORKSPACE
+COPY . /protos/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.8
+
+# Add the protos to the Docker image.
+ADD ./google /protos/google
+
+# Add Bazel build data to the image.
+ADD ./BUILD.bazel /protos/BUILD.bazel
+ADD ./WORKSPACE /protos/WORKSPACE


### PR DESCRIPTION
This commit adds support for deploying a Docker image when we issue a release.

The usefulness of this assumes a release strategy (which we more or less do not have yet), but getting this in place at least allows us to create gapic-generator-{lang} Docker images that can depend on this.