### PR TITLE
Add cc proto library rule

### DIFF
--- a/google/api/BUILD.bazel
+++ b/google/api/BUILD.bazel
@@ -55,6 +55,11 @@ proto_library(
     ],
 )
 
+cc_proto_library(
+		name = "client_cc_proto",
+  	deps = [":client_proto"],
+)
+
 proto_library(
     name = "config_change_proto",
     srcs = ["config_change.proto"],

--- a/google/api/BUILD.bazel
+++ b/google/api/BUILD.bazel
@@ -56,8 +56,8 @@ proto_library(
 )
 
 cc_proto_library(
-		name = "client_cc_proto",
-  	deps = [":client_proto"],
+    name = "client_cc_proto",
+    deps = [":client_proto"],
 )
 
 proto_library(


### PR DESCRIPTION
This rule will be consumed by the C++ GAPIC generator.