### PR TITLE
api/resource: allow referencing multiple types/child_types

### DIFF
--- a/google/api/resource.proto
+++ b/google/api/resource.proto
@@ -172,7 +172,7 @@ message ResourceReference {
   //       type = "pubsub.googleapis.com/Topic"
   //     }];
   //   }
-  string type = 1;
+  repeated string type = 1;
 
   // The fully-qualified message name of a child of the type that this field
   // references.
@@ -195,5 +195,5 @@ message ResourceReference {
   //     string parent = 1
   //       [(google.api.resource_reference).child_type = "LogEntry"];
   //   }
-  string child_type = 2;
+  repeated string child_type = 2;
 }


### PR DESCRIPTION
This change allows to use resource_reference in fields where multiple
source types are possible as it's the case for `Role` or `LogEntry`
resources.

```
message ListRolesRequest {
    string parent = 1 [
        (google.api.resource_reference).type = "",
        (google.api.resource_reference).type = "Organization",
        (google.api.resource_reference).type = "Project"
    ]
}
```

Fixes #47

Signed-off-by: Gorka Lerchundi Osa <glertxundi@gmail.com>