### PR TITLE
Fix link to Go package in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ dependency, and which makes these types available.
 
   * **C#**: [Google.Api.CommonProtos](https://www.nuget.org/packages/Google.Api.CommonProtos/)
   * **Java**: [proto-google-common-protos](https://mvnrepository.com/artifact/com.google.api.grpc/proto-google-common-protos)
-  * **Go**: [google.golang.org/genproto/googleapis]()
+  * **Go**: [google.golang.org/genproto/googleapis](https://godoc.org/google.golang.org/genproto/googleapis)
   * **Node.js**: [google-proto-files](https://www.npmjs.com/package/google-proto-files)
   * **PHP**: [gax-php](https://github.com/googleapis/gax-php)
   * **Python**: [googleapis-common-protos](https://pypi.org/project/googleapis-common-protos/)


### PR DESCRIPTION
The link is currently empty and thus leads to https://github.com/googleapis/api-common-protos/blob/master which returns 404. The patch sets the proper link to godoc for the `genproto` package.