### PR TITLE
feat: update base types to those from protobuf 3.11.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8
 RUN apk add --no-cache curl unzip
 
 # Add protoc.
-ENV PROTOBUF_VERSION 3.6.1
+ENV PROTOBUF_VERSION 3.11.4
 RUN mkdir -p /usr/src/protoc/ \
     && curl --location https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip > /usr/src/protoc/protoc-${PROTOBUF_VERSION}.zip \
     && cd /usr/src/protoc/ \


### PR DESCRIPTION
The base (e.g. `google/protobuf/*.proto` are from protobuf 3.6, which means they don't include documentation fixes from the past year and a half. This is causing various issues such as https://github.com/googleapis/google-cloud-ruby/issues/5188