### PR TITLE
chore: copy several proto files from googleapis to remove some noise from google-cloud-ruby regens

### DIFF
--- a/google/api/client.proto
+++ b/google/api/client.proto
@@ -1,10 +1,10 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,43 +23,6 @@ option java_multiple_files = true;
 option java_outer_classname = "ClientProto";
 option java_package = "com.google.api";
 option objc_class_prefix = "GAPI";
-
-
-extend google.protobuf.ServiceOptions {
-  // The hostname for this service.
-  // This should be specified with no prefix or protocol.
-  //
-  // Example:
-  //
-  //   service Foo {
-  //     option (google.api.default_host) = "foo.googleapi.com";
-  //     ...
-  //   }
-  string default_host = 1049;
-
-  // OAuth scopes needed for the client.
-  //
-  // Example:
-  //
-  //   service Foo {
-  //     option (google.api.oauth_scopes) = \
-  //       "https://www.googleapis.com/auth/cloud-platform";
-  //     ...
-  //   }
-  //
-  // If there is more than one scope, use a comma-separated string:
-  //
-  // Example:
-  //
-  //   service Foo {
-  //     option (google.api.oauth_scopes) = \
-  //       "https://www.googleapis.com/auth/cloud-platform,"
-  //       "https://www.googleapis.com/auth/monitoring";
-  //     ...
-  //   }
-  string oauth_scopes = 1050;
-}
-
 
 extend google.protobuf.MethodOptions {
   // A definition of a client library method signature.
@@ -98,4 +61,39 @@ extend google.protobuf.MethodOptions {
   //   * Re-ordering existing method signature annotations is a breaking
   //     change.
   repeated string method_signature = 1051;
+}
+
+extend google.protobuf.ServiceOptions {
+  // The hostname for this service.
+  // This should be specified with no prefix or protocol.
+  //
+  // Example:
+  //
+  //   service Foo {
+  //     option (google.api.default_host) = "foo.googleapi.com";
+  //     ...
+  //   }
+  string default_host = 1049;
+
+  // OAuth scopes needed for the client.
+  //
+  // Example:
+  //
+  //   service Foo {
+  //     option (google.api.oauth_scopes) = \
+  //       "https://www.googleapis.com/auth/cloud-platform";
+  //     ...
+  //   }
+  //
+  // If there is more than one scope, use a comma-separated string:
+  //
+  // Example:
+  //
+  //   service Foo {
+  //     option (google.api.oauth_scopes) = \
+  //       "https://www.googleapis.com/auth/cloud-platform,"
+  //       "https://www.googleapis.com/auth/monitoring";
+  //     ...
+  //   }
+  string oauth_scopes = 1050;
 }

--- a/google/api/field_behavior.proto
+++ b/google/api/field_behavior.proto
@@ -1,10 +1,10 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,6 +24,21 @@ option java_outer_classname = "FieldBehaviorProto";
 option java_package = "com.google.api";
 option objc_class_prefix = "GAPI";
 
+extend google.protobuf.FieldOptions {
+  // A designation of a specific field behavior (required, output only, etc.)
+  // in protobuf messages.
+  //
+  // Examples:
+  //
+  //   string name = 1 [(google.api.field_behavior) = REQUIRED];
+  //   State state = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  //   google.protobuf.Duration ttl = 1
+  //     [(google.api.field_behavior) = INPUT_ONLY];
+  //   google.protobuf.Timestamp expire_time = 1
+  //     [(google.api.field_behavior) = OUTPUT_ONLY,
+  //      (google.api.field_behavior) = IMMUTABLE];
+  repeated google.api.FieldBehavior field_behavior = 1052;
+}
 
 // An indicator of the behavior of a given field (for example, that a field
 // is required in requests, or given as output but ignored as input).
@@ -60,21 +75,10 @@ enum FieldBehavior {
   // This indicates that the field may be set once in a request to create a
   // resource, but may not be changed thereafter.
   IMMUTABLE = 5;
-}
 
-
-extend google.protobuf.FieldOptions {
-  // A designation of a specific field behavior (required, output only, etc.)
-  // in protobuf messages.
-  //
-  // Examples:
-  //
-  //   string name = 1 [(google.api.field_behavior) = REQUIRED];
-  //   State state = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-  //   google.protobuf.Duration ttl = 1
-  //     [(google.api.field_behavior) = INPUT_ONLY];
-  //   google.protobuf.Timestamp expire_time = 1
-  //     [(google.api.field_behavior) = OUTPUT_ONLY,
-  //      (google.api.field_behavior) = IMMUTABLE];
-  repeated FieldBehavior field_behavior = 1052;
+  // Denotes that a (repeated) field is an unordered list.
+  // This indicates that the service may provide the elements of the list
+  // in any arbitrary order, rather than the order the user originally
+  // provided. Additionally, the list's order may or may not be stable.
+  UNORDERED_LIST = 6;
 }

--- a/google/longrunning/operations.proto
+++ b/google/longrunning/operations.proto
@@ -1,10 +1,10 @@
-// Copyright 2016 Google Inc.
+// Copyright 2019 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,11 +17,14 @@ syntax = "proto3";
 package google.longrunning;
 
 import "google/api/annotations.proto";
+import "google/api/client.proto";
 import "google/protobuf/any.proto";
-import "google/protobuf/descriptor.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/rpc/status.proto";
+import "google/protobuf/descriptor.proto";
 
+option cc_enable_arenas = true;
 option csharp_namespace = "Google.LongRunning";
 option go_package = "google.golang.org/genproto/googleapis/longrunning;longrunning";
 option java_multiple_files = true;
@@ -29,6 +32,15 @@ option java_outer_classname = "OperationsProto";
 option java_package = "com.google.longrunning";
 option php_namespace = "Google\\LongRunning";
 
+extend google.protobuf.MethodOptions {
+  // Additional information regarding long-running operations.
+  // In particular, this specifies the types that are returned from
+  // long-running operations.
+  //
+  // Required for methods that return `google.longrunning.Operation`; invalid
+  // otherwise.
+  google.longrunning.OperationInfo operation_info = 1049;
+}
 
 // Manages long-running operations with an API service.
 //
@@ -40,20 +52,33 @@ option php_namespace = "Google\\LongRunning";
 // returns long-running operations should implement the `Operations` interface
 // so developers can have a consistent client experience.
 service Operations {
+  option (google.api.default_host) = "longrunning.googleapis.com";
+
   // Lists operations that match the specified filter in the request. If the
   // server doesn't support this method, it returns `UNIMPLEMENTED`.
   //
-  // NOTE: the `name` binding below allows API services to override the binding
-  // to use different resource name schemes, such as `users/*/operations`.
+  // NOTE: the `name` binding allows API services to override the binding
+  // to use different resource name schemes, such as `users/*/operations`. To
+  // override the binding, API services can add a binding such as
+  // `"/v1/{name=users/*}/operations"` to their service configuration.
+  // For backwards compatibility, the default name includes the operations
+  // collection id, however overriding users must ensure the name binding
+  // is the parent resource, without the operations collection id.
   rpc ListOperations(ListOperationsRequest) returns (ListOperationsResponse) {
-    option (google.api.http) = { get: "/v1/{name=operations}" };
+    option (google.api.http) = {
+      get: "/v1/{name=operations}"
+    };
+    option (google.api.method_signature) = "name,filter";
   }
 
   // Gets the latest state of a long-running operation.  Clients can use this
   // method to poll the operation result at intervals as recommended by the API
   // service.
   rpc GetOperation(GetOperationRequest) returns (Operation) {
-    option (google.api.http) = { get: "/v1/{name=operations/**}" };
+    option (google.api.http) = {
+      get: "/v1/{name=operations/**}"
+    };
+    option (google.api.method_signature) = "name";
   }
 
   // Deletes a long-running operation. This method indicates that the client is
@@ -61,7 +86,10 @@ service Operations {
   // operation. If the server doesn't support this method, it returns
   // `google.rpc.Code.UNIMPLEMENTED`.
   rpc DeleteOperation(DeleteOperationRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = { delete: "/v1/{name=operations/**}" };
+    option (google.api.http) = {
+      delete: "/v1/{name=operations/**}"
+    };
+    option (google.api.method_signature) = "name";
   }
 
   // Starts asynchronous cancellation on a long-running operation.  The server
@@ -75,7 +103,23 @@ service Operations {
   // an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
   // corresponding to `Code.CANCELLED`.
   rpc CancelOperation(CancelOperationRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = { post: "/v1/{name=operations/**}:cancel" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{name=operations/**}:cancel"
+      body: "*"
+    };
+    option (google.api.method_signature) = "name";
+  }
+
+  // Waits for the specified long-running operation until it is done or reaches
+  // at most a specified timeout, returning the latest state.  If the operation
+  // is already done, the latest state is immediately returned.  If the timeout
+  // specified is greater than the default HTTP/RPC timeout, the HTTP/RPC
+  // timeout is used.  If the server does not support this method, it returns
+  // `google.rpc.Code.UNIMPLEMENTED`.
+  // Note that this method is on a best-effort basis.  It may return the latest
+  // state before the specified timeout (including immediately), meaning even an
+  // immediate response is no guarantee that the operation is done.
+  rpc WaitOperation(WaitOperationRequest) returns (Operation) {
   }
 }
 
@@ -84,7 +128,7 @@ service Operations {
 message Operation {
   // The server-assigned name, which is only unique within the same service that
   // originally returns it. If you use the default HTTP mapping, the
-  // `name` should have the format of `operations/some/unique/name`.
+  // `name` should be a resource name ending with `operations/{unique_id}`.
   string name = 1;
 
   // Service-specific metadata associated with the operation.  It typically
@@ -94,7 +138,7 @@ message Operation {
   google.protobuf.Any metadata = 2;
 
   // If the value is `false`, it means the operation is still in progress.
-  // If true, the operation is completed, and either `error` or `response` is
+  // If `true`, the operation is completed, and either `error` or `response` is
   // available.
   bool done = 3;
 
@@ -125,7 +169,7 @@ message GetOperationRequest {
 
 // The request message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
 message ListOperationsRequest {
-  // The name of the operation collection.
+  // The name of the operation's parent resource.
   string name = 4;
 
   // The standard list filter.
@@ -159,6 +203,17 @@ message DeleteOperationRequest {
   string name = 1;
 }
 
+// The request message for [Operations.WaitOperation][google.longrunning.Operations.WaitOperation].
+message WaitOperationRequest {
+  // The name of the operation resource to wait on.
+  string name = 1;
+
+  // The maximum duration to wait before timing out. If left blank, the wait
+  // will be at most the time permitted by the underlying HTTP/RPC protocol.
+  // If RPC context deadline is also specified, the shorter one will be used.
+  google.protobuf.Duration timeout = 2;
+}
+
 // A message representing the message types used by a long-running operation.
 //
 // Example:
@@ -189,14 +244,4 @@ message OperationInfo {
   //
   // Note: Altering this value constitutes a breaking change.
   string metadata_type = 2;
-}
-
-extend google.protobuf.MethodOptions {
-  // Additional information regarding long-running operations.
-  // In particular, this specifies the types that are returned from
-  // long-running operations.
-  //
-  // Required for methods that return `google.longrunning.Operation`; invalid
-  // otherwise.
-  OperationInfo operation_info = 1049;
 }

--- a/google/type/latlng.proto
+++ b/google/type/latlng.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -24,8 +23,8 @@ option java_outer_classname = "LatLngProto";
 option java_package = "com.google.type";
 option objc_class_prefix = "GTP";
 
-// An object representing a latitude/longitude pair. This is expressed as a pair
-// of doubles representing degrees latitude and degrees longitude. Unless
+// An object that represents a latitude/longitude pair. This is expressed as a
+// pair of doubles to represent degrees latitude and degrees longitude. Unless
 // specified otherwise, this must conform to the
 // <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
 // standard</a>. Values must be within normalized ranges.


### PR DESCRIPTION
copy api/client.proto api/field_behavior.proto, longrunning/operations.proto, type/latlng.proto from googleapis
copied from https://github.com/googleapis/googleapis/commit/d99d5d592f3d1d5526511c90120b1e9ab3ce6e17 commit